### PR TITLE
Fix blog post static generation and add debugging

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -86,6 +86,7 @@ export async function generateStaticParams() {
         'Content-Type': 'application/json',
         'Cache-Control': 'no-cache, no-store, must-revalidate',
       },
+      cache: 'no-store',
       body: JSON.stringify({
         query: `
           query Publication {
@@ -94,6 +95,8 @@ export async function generateStaticParams() {
                 edges {
                   node {
                     slug
+                    title
+                    publishedAt
                   }
                 }
               }


### PR DESCRIPTION
New blog post "before-tech-my-first-love-was-literature" appears in blog listing but clicking it redirects to home page. Local builds generate 18 pages successfully, but Netlify only generates 17 pages, despite manually re-deploying without cache.

Likely cause: Netlify is hitting cached Hashnode API responses that don't include the newest article. Added cache-busting headers and logging to diagnose.

### Changes:
- Added cache-busting headers to `generateStaticParams()` to prevent stale API responses
- Added logging to track which blog post slugs are being generated during build

### Debug Info:
- Local builds generate 18 pages, while Netlify generates 17
- Logs will help identify which post is missing from Netlify builds

Fixed: all slugs correctly fetched and generated
<img width="704" height="257" alt="image" src="https://github.com/user-attachments/assets/eee59ef9-5560-4cf4-839f-0ba1a6f3e107" />
