### PR TITLE
fix: caching issue on Netlify

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -97,9 +97,13 @@ export async function generateStaticParams() {
               posts(first: 50) {
                 edges {
                   node {
+                    id
                     slug
                     title
                     publishedAt
+                    author {
+                      name
+                    }
                   }
                 }
               }


### PR DESCRIPTION
**Problem:**
Local builds generated 14 blog posts, but Netlify consistently generated only 12. Missing posts appeared in blog listing but resulted in 404 errors.

**Root Cause:**
Hashnode's CDN serves cached API responses based on GraphQL query signature. Netlify's build servers (different geographic region) hit CDN edge servers with stale cache containing only 12 posts instead of 14.

**Solution:**
Modified GraphQL query in `generateStaticParams()` to include additional fields, changing the query signature and forcing Hashnode's CDN to use a different cache key that returns fresh data.

**Result:**
✅ Netlify now generates all 14 blog posts consistently

<img width="819" height="346" alt="image" src="https://github.com/user-attachments/assets/5d6b8a18-b9c8-4260-ad53-0597fe3588d1" />
