### PR TITLE
Add Beehiiv subscription with tag to waitlist automation

### DIFF
--- a/app/api/submit-waitlist/route.ts
+++ b/app/api/submit-waitlist/route.ts
@@ -1,6 +1,8 @@
 /**
  * API Route: POST /api/submit-waitlist
- * Handles techie-taboo waitlist form submissions and forwards to Netlify Forms
+ * Handles techie-taboo waitlist form submissions with automated workflows:
+ * 1. Submit to Netlify Forms
+ * 2. Subscribe to Beehiiv and add "techie taboo waitlisters" tag
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -17,6 +19,9 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    // Get request metadata
+    const referrer = request.headers.get('referer') || 'direct';
 
     // Create FormData for Netlify Forms submission
     const netlifyFormData = new FormData();
@@ -43,6 +48,62 @@ export async function POST(request: NextRequest) {
     }
 
     console.log('Waitlist submission successful:', { name, email });
+
+    // Workflow: Subscribe to Beehiiv and add tag (non-blocking)
+    try {
+      const beehiivApiKey = process.env.BEEHIIV_API_KEY;
+      const publicationId = process.env.BEEHIIV_PUBLICATION_ID;
+
+      // Step 1: Create subscription
+      const subscriptionResponse = await fetch(
+        `https://api.beehiiv.com/v2/publications/${publicationId}/subscriptions`,
+        {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${beehiivApiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            email,
+            reactivate_existing: false,
+            send_welcome_email: false,
+            utm_source: 'techie-taboo-waitlist',
+            utm_medium: 'website',
+            referring_site: referrer,
+          }),
+        }
+      );
+
+      if (subscriptionResponse.ok) {
+        const subscriptionData = await subscriptionResponse.json();
+        const subscriptionId = subscriptionData.data.id;
+        
+        // Step 2: Add tag to subscription
+        const tagResponse = await fetch(
+          `https://api.beehiiv.com/v2/publications/${publicationId}/subscriptions/${subscriptionId}/tags`,
+          {
+            method: 'POST',
+            headers: {
+              'Authorization': `Bearer ${beehiivApiKey}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              tags: ['techie taboo waitlisters'],
+            }),
+          }
+        );
+
+        if (tagResponse.ok) {
+          console.log('Added to Beehiiv with tag:', { email, subscriptionId });
+        } else {
+          console.error('Failed to add tag:', await tagResponse.text());
+        }
+      } else {
+        console.error('Beehiiv subscription failed:', await subscriptionResponse.text());
+      }
+    } catch (error) {
+      console.error('Beehiiv workflow error:', error);
+    }
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
### Changes
- When users join the waitlist, automatically subscribe users to Beehiiv with "techie taboo waitlisters" tag
- Track UTM parameters (source: techie-taboo-waitlist, medium: website)
- Non-blocking workflow - won't interrupt Netlify Forms submission

## TESTED successfully
<img width="1113" height="101" alt="image" src="https://github.com/user-attachments/assets/45cc394a-bf81-4c06-afd7-de53ec6c7d39" />
