### PR TITLE
fix: beehiiv cover image not showing

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,10 @@ const nextConfig = {
           protocol: 'https',
           hostname: '**.beehiiv.com',
         },
+        {
+          protocol: 'https',
+          hostname: 'beehiiv-images-production.s3.amazonaws.com',
+        },
       ],
     },
   };


### PR DESCRIPTION
# Issue
Cover images were not showing for our beehiiv posts with error:
```json
 error: {"code":400,"msg":"url (https://beehiiv-images-production.s3.amazonaws.com/uploads/asset/file/e4fbf2c9-0d6f-4510-b092-59e9aefe862e/thumbnail.png?t=1770018122) is not an allowed pattern","error_id":"01KGK7QRRN8ZD5ZFEX58SG0KWE"} 
 ```

# Solution
Added the beehiiv S3 bucket hostname (beehiiv-images-production.s3.amazonaws.com) to the allowed remote image patterns in `next.config.mjs`.