### PR TITLE
blog: publish vibe coding post at 8am SGT

### DIFF
--- a/data/posts/2026-08-10-vibe-coding-is-dead-long-live-agentic-engineering/index.md
+++ b/data/posts/2026-08-10-vibe-coding-is-dead-long-live-agentic-engineering/index.md
@@ -4,11 +4,11 @@ slug: "vibe-coding-is-dead-long-live-agentic-engineering"
 author:
   name: "ragTech Team"
   profilePicture: "/assets/logo/ragtech-logo.png"
-publishedAt: "2026-08-10T12:00:00Z"
+publishedAt: "2026-08-10T00:00:00Z"
 coverImage: "https://i.ytimg.com/vi/96jN2OCOfLs/maxresdefault.jpg"
 brief: "Andrej Karpathy coined vibe coding in 2025. A year later, at Sequoia's AI Ascent 2026, he told everyone to move on from it. We break down what agentic engineering actually means, and why the data backs him up."
 tags: ["vibe coding", "agentic engineering", "coding agents", "software engineering", "AI tools"]
-status: "scheduled"
+status: "published"
 topic:
   - "ragTech"
 readTimeInMinutes: 5


### PR DESCRIPTION
The Aug 10 vibe coding post was not appearing on the live site. It was working as designed — `publishedAt` was set to `2026-08-10T12:00:00Z`, which is **8pm** Singapore time, not the intended 8am.

Corrected to `00:00:00Z` (8am SGT, already passed) and flipped `status` to `published` so the post goes live as soon as this deploys.

Blog routes are `force-dynamic`, so no scheduling wait is involved — the post is visible immediately on deploy.

Newsletter is unaffected: `sent: false` remains, and there is no cron for `send-pending`, so it only goes out when `npm run newsletter:send-pending` is run manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)